### PR TITLE
エラー発生時のバックトレースを標準エラー出力に書き出さないようにする

### DIFF
--- a/lib/origami/parsers/pdf/linear.rb
+++ b/lib/origami/parsers/pdf/linear.rb
@@ -31,7 +31,7 @@ module Origami
         class LinearParser < Parser
             def parse(stream)
                 super
-            
+
                 pdf = parse_initialize
 
                 #
@@ -48,7 +48,7 @@ module Origami
                     rescue
                         error "Cannot read : " + (@data.peek(10) + "...").inspect
                         error "Stopped on exception : " + $!.message
-                        STDERR.puts $!.backtrace.join($/)
+                        error $!.backtrace.join($/)
 
                         break
                     end


### PR DESCRIPTION
## 背景

https://github.com/sight-visit/ninja-sign/issues/26105

OrigamiでパースできないPDFの場合、エラーのバックトレースがフォアグラウンドに書き出されてしまうので、
logger を渡しているのでそれを経由してログに書き出すようにしました。